### PR TITLE
feat: expose postgres with extension

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# vim: syntax=bash
+
+. ./bin/direnvrc
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 **/*.rs.bk
 sql/arrays-1.0.sql
 result
+.direnv
+.data

--- a/flake-parts/postgres.nix
+++ b/flake-parts/postgres.nix
@@ -1,0 +1,12 @@
+{...}: {
+  perSystem = {
+    pkgs,
+    self',
+    ...
+  }: {
+    packages = rec {
+      postgresql-target = pkgs.postgresql_15;
+      postgresql = self'.packages.postgresql-target.withPackages (ps: [self'.packages.pgrx-arrays]);
+    };
+  };
+}

--- a/flake-parts/services.nix
+++ b/flake-parts/services.nix
@@ -1,0 +1,49 @@
+{inputs, ...} @ part-inputs: {
+  imports = [];
+
+  perSystem = {
+    pkgs,
+    inputs',
+    self',
+    ...
+  }: let
+    # define some values that are used in multiple places.
+    # this is used to ensure that all services data is kept in the same directory, and that
+    # each service has its own directory within the main one.
+    # if there were flake input variables we could determine the dataDir from those, but
+    # since there aren't we will allow for an environment variable and a sensible default.
+    ports = {
+      pg1 = "\${PG1_PORT}";
+    };
+
+    global-imports = [
+      ({name, ...}: {
+        dataDirEnv = "\${PRJ_DATA_HOME}/${name}";
+        socketDirEnv = "\${PRJ_DATA_HOME}/${name}/sockets";
+      })
+    ];
+  in rec {
+    process-compose = {
+      services = {
+        imports = [
+          inputs.services-flake.processComposeModules.default
+        ];
+
+        services.postgres."pg1" = {
+          imports = global-imports;
+
+          enable = true;
+          package = self'.packages.postgresql;
+
+          listen_addresses = "127.0.0.1";
+          port = ports."pg1";
+          initialDatabases = [
+            {
+              name = "array-example";
+            }
+          ];
+        };
+      };
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -212,6 +212,21 @@
         "type": "github"
       }
     },
+    "process-compose": {
+      "locked": {
+        "lastModified": 1713920695,
+        "narHash": "sha256-pQIg3wrNBDdRiuhcVC8DFmTXK8GHtR+iV+5Gvsozx5s=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "ee8cd505f08f6cd691930e70987a306b7726851b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
@@ -219,7 +234,9 @@
         "flake-parts": "flake-parts",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "pgrx": "pgrx"
+        "pgrx": "pgrx",
+        "process-compose": "process-compose",
+        "services-flake": "services-flake"
       }
     },
     "rust-analyzer-src": {
@@ -236,6 +253,21 @@
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "services-flake": {
+      "locked": {
+        "lastModified": 1709510351,
+        "narHash": "sha256-FIG8YmvSoy99Z7jrcXZi2Mw11lM53Z2ex8cQ1h1Y6eU=",
+        "owner": "justinrubek",
+        "repo": "services-flake",
+        "rev": "577e7d44d9d0314697c625ff1fdbb4ad8b5fade3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinrubek",
+        "repo": "services-flake",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -16,21 +16,32 @@
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    process-compose.url = "github:Platonic-Systems/process-compose-flake";
+    services-flake.url = "github:justinrubek/services-flake";
   };
 
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux"];
+      imports = [
+        inputs.process-compose.flakeModule
+        ./flake-parts/services.nix
+        ./flake-parts/postgres.nix
+      ];
       perSystem = {
         pkgs,
         system,
         inputs',
+        self',
         ...
       }: {
+        devShells.default = pkgs.mkShell {
+          packages = [self'.packages.postgresql];
+        };
         packages = {
           pgrx-arrays = inputs.pgrx.lib.buildPgrxExtension {
             inherit system;
-            postgresql = pkgs.postgresql_15;
+            postgresql = self'.packages.postgresql-target;
             rustToolchain = inputs'.fenix.packages.stable.toolchain;
             src = inputs.nix-filter.lib {
               root = ./.;


### PR DESCRIPTION
This uses services-flake to run postgres locally, but also exposes the `postgresql` flake package when can be used to run postgres. To run it locally, use `nix run .#services`. This command will expect environment variables set: `PRJ_DATA_HOME` and `PG1_PORT`. For convenience, direnv will look in the `.direnv/env` directory for files that define environment variables (the file name is the variable name and file contents are its value).

This postgres has been verified to work with the extension:
```
➜ psql -h 127.0.0.1 -d array-example -p 5435
psql (15.6)
Type "help" for help.

array-example=# CREATE EXTENSION arrays;
WARNING:  creating sample data in the table 'vectors.data'.
CREATE EXTENSION
array-example=#
```